### PR TITLE
fix: document source preview on detail page (issue #4)

### DIFF
--- a/app/(dashboard)/documents/[id]/page.tsx
+++ b/app/(dashboard)/documents/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   DocumentSummary,
   getDocumentResult,
   getDownloadUrl,
+  getSourceUrl,
   ParseResult,
 } from "@/lib/document-agent-api";
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
@@ -25,6 +26,8 @@ export default function DocumentDetailPage() {
   const [result, setResult] = useState<ParseResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const previewUrl = doc ? getSourceUrl(doc.id) : null;
 
   useEffect(() => {
     const fetchDocDetail = async () => {
@@ -95,8 +98,12 @@ export default function DocumentDetailPage() {
             목록으로 돌아가기
           </Button>
           <div className="flex gap-2">
-            <Badge variant="outline" className="text-[10px] font-bold text-zinc-400 border-zinc-200 bg-white dark:bg-zinc-900 h-5">PDF</Badge>
-            <Badge variant="outline" className="text-[10px] font-bold text-zinc-400 border-zinc-200 bg-white dark:bg-zinc-900 h-5">Preview Pending</Badge>
+            <Badge variant="outline" className="text-[10px] font-bold text-zinc-400 border-zinc-200 bg-white dark:bg-zinc-900 h-5 uppercase">
+              {doc.contentType.split("/")[1] || "FILE"}
+            </Badge>
+            <Badge variant="outline" className="text-[10px] font-bold text-emerald-600 border-emerald-100 bg-emerald-50 dark:bg-emerald-950/30 dark:border-emerald-900/30 h-5">
+              Source Loaded
+            </Badge>
           </div>
         </div>
       </div>
@@ -140,7 +147,14 @@ export default function DocumentDetailPage() {
               <p className="text-zinc-400 text-xs text-balance">원문 파일 또는 preview endpoint가 연결되면 이 영역에서 직접 내용을 검수합니다.</p>
             </div>
           </CardHeader>
-          <CardContent className="flex-1 flex flex-col items-center justify-center bg-zinc-50/20 dark:bg-zinc-900/20 relative">
+          <CardContent className="flex-1 p-0 bg-zinc-50/20 dark:bg-zinc-900/20 relative overflow-hidden">
+            {previewUrl ? (
+              <iframe
+                src={previewUrl}
+                className="w-full h-full border-none"
+                title="Document Preview"
+              />
+            ) : (
              <div className="absolute inset-8 border-2 border-dashed border-zinc-100 dark:border-zinc-800 rounded-2xl flex flex-col items-center justify-center text-center p-8 space-y-4">
                 <div className="h-16 w-16 bg-white dark:bg-zinc-800 rounded-full flex items-center justify-center shadow-sm border border-zinc-50 dark:border-zinc-700">
                   <EyeOff className="h-8 w-8 text-zinc-200" />
@@ -148,10 +162,11 @@ export default function DocumentDetailPage() {
                 <div className="space-y-2">
                   <h3 className="text-xl font-bold">PDF 미리보기 패널</h3>
                   <p className="text-xs text-zinc-400 max-w-xs mx-auto leading-relaxed">
-                    현재 API 응답에는 원문을 직접 임베드할 preview URL이 포함되어 있지 않습니다. backend가 sourceUrl 또는 preview endpoint를 제공하면 이 패널에 바로 연결됩니다.
+                    문서를 불러올 수 없습니다. API 연결 상태를 확인해 주세요.
                   </p>
                 </div>
              </div>
+            )}
           </CardContent>
         </Card>
 

--- a/app/(dashboard)/documents/[id]/page.tsx
+++ b/app/(dashboard)/documents/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import {
@@ -18,6 +18,26 @@ import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
+type PreviewStatus = "idle" | "loading" | "loaded" | "error";
+
+function parsePreviewErrorMessage(rawText: string): string {
+  try {
+    const parsed = JSON.parse(rawText) as {
+      error?: {
+        message?: string;
+      };
+    };
+    const message = parsed.error?.message?.trim();
+    if (message) {
+      return message;
+    }
+  } catch {
+    // Fall through to the generic preview error message.
+  }
+
+  return "문서를 불러오지 못했습니다. API 연결 상태를 확인해 주세요.";
+}
+
 export default function DocumentDetailPage() {
   const params = useParams<{ id: string }>();
   const documentId = Array.isArray(params.id) ? params.id[0] : params.id;
@@ -26,6 +46,9 @@ export default function DocumentDetailPage() {
   const [result, setResult] = useState<ParseResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [previewStatus, setPreviewStatus] = useState<PreviewStatus>("idle");
+  const [previewMessage, setPreviewMessage] = useState<string | null>(null);
+  const previewFrameRef = useRef<HTMLIFrameElement | null>(null);
 
   const previewUrl = doc ? getSourceUrl(doc.id) : null;
 
@@ -56,6 +79,17 @@ export default function DocumentDetailPage() {
     fetchDocDetail();
   }, [documentId]);
 
+  useEffect(() => {
+    if (!previewUrl) {
+      setPreviewStatus("idle");
+      setPreviewMessage(null);
+      return;
+    }
+
+    setPreviewStatus("loading");
+    setPreviewMessage(null);
+  }, [previewUrl]);
+
   const handleDelete = async () => {
     if (!documentId) return;
     if (!confirm("Are you sure you want to delete this document?")) return;
@@ -72,6 +106,41 @@ export default function DocumentDetailPage() {
       }
     }
   };
+
+  const handlePreviewLoad = () => {
+    const iframeDocument = previewFrameRef.current?.contentDocument;
+    const iframeContentType = iframeDocument?.contentType?.toLowerCase() ?? "";
+    const iframeBodyText = iframeDocument?.body?.innerText?.trim() ?? "";
+
+    if (
+      (iframeContentType.includes("application/json") || iframeContentType.includes("text/plain")) &&
+      iframeBodyText
+    ) {
+      setPreviewMessage(parsePreviewErrorMessage(iframeBodyText));
+      setPreviewStatus("error");
+      return;
+    }
+
+    setPreviewStatus("loaded");
+  };
+
+  const handlePreviewError = () => {
+    setPreviewMessage("문서를 불러오지 못했습니다. API 연결 상태를 확인해 주세요.");
+    setPreviewStatus("error");
+  };
+
+  const previewStatusLabel =
+    previewStatus === "loaded"
+      ? "Source Loaded"
+      : previewStatus === "loading"
+        ? "Source Loading"
+        : "Source Unavailable";
+  const previewStatusClassName =
+    previewStatus === "loaded"
+      ? "text-[10px] font-bold text-emerald-600 border-emerald-100 bg-emerald-50 dark:bg-emerald-950/30 dark:border-emerald-900/30 h-5"
+      : previewStatus === "loading"
+        ? "text-[10px] font-bold text-amber-700 border-amber-100 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-900/30 h-5"
+        : "text-[10px] font-bold text-red-600 border-red-100 bg-red-50 dark:bg-red-950/30 dark:border-red-900/30 h-5";
 
   if (loading) {
     return (
@@ -101,8 +170,8 @@ export default function DocumentDetailPage() {
             <Badge variant="outline" className="text-[10px] font-bold text-zinc-400 border-zinc-200 bg-white dark:bg-zinc-900 h-5 uppercase">
               {doc.contentType.split("/")[1] || "FILE"}
             </Badge>
-            <Badge variant="outline" className="text-[10px] font-bold text-emerald-600 border-emerald-100 bg-emerald-50 dark:bg-emerald-950/30 dark:border-emerald-900/30 h-5">
-              Source Loaded
+            <Badge variant="outline" className={previewStatusClassName}>
+              {previewStatusLabel}
             </Badge>
           </div>
         </div>
@@ -144,25 +213,42 @@ export default function DocumentDetailPage() {
             <div className="space-y-1">
               <Badge variant="secondary" className="bg-zinc-100 dark:bg-zinc-800 text-zinc-500 border-zinc-200 px-2 py-0 text-[10px]">Original Preview</Badge>
               <h2 className="text-lg font-bold">원문 미리보기 패널</h2>
-              <p className="text-zinc-400 text-xs text-balance">원문 파일 또는 preview endpoint가 연결되면 이 영역에서 직접 내용을 검수합니다.</p>
+              <p className="text-zinc-400 text-xs text-balance">원문 파일이 정상적으로 로드되면 이 영역에서 직접 내용을 검수합니다.</p>
             </div>
           </CardHeader>
           <CardContent className="flex-1 p-0 bg-zinc-50/20 dark:bg-zinc-900/20 relative overflow-hidden">
-            {previewUrl ? (
-              <iframe
-                src={previewUrl}
-                className="w-full h-full border-none"
-                title="Document Preview"
-              />
+            {previewUrl && previewStatus !== "error" ? (
+              <>
+                <iframe
+                  ref={previewFrameRef}
+                  src={previewUrl}
+                  className="w-full h-full border-none"
+                  title="Document Preview"
+                  onLoad={handlePreviewLoad}
+                  onError={handlePreviewError}
+                />
+                {previewStatus === "loading" && (
+                  <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-white/80 dark:bg-zinc-950/80">
+                    <Loader2 className="h-6 w-6 animate-spin text-zinc-400" />
+                    <p className="text-xs font-medium text-zinc-500">원문 미리보기를 불러오는 중입니다.</p>
+                  </div>
+                )}
+              </>
             ) : (
              <div className="absolute inset-8 border-2 border-dashed border-zinc-100 dark:border-zinc-800 rounded-2xl flex flex-col items-center justify-center text-center p-8 space-y-4">
                 <div className="h-16 w-16 bg-white dark:bg-zinc-800 rounded-full flex items-center justify-center shadow-sm border border-zinc-50 dark:border-zinc-700">
-                  <EyeOff className="h-8 w-8 text-zinc-200" />
+                  {previewStatus === "error" ? (
+                    <AlertCircle className="h-8 w-8 text-red-300" />
+                  ) : (
+                    <EyeOff className="h-8 w-8 text-zinc-200" />
+                  )}
                 </div>
                 <div className="space-y-2">
-                  <h3 className="text-xl font-bold">PDF 미리보기 패널</h3>
+                  <h3 className="text-xl font-bold">
+                    {previewStatus === "error" ? "원문 미리보기를 불러오지 못했습니다" : "PDF 미리보기 패널"}
+                  </h3>
                   <p className="text-xs text-zinc-400 max-w-xs mx-auto leading-relaxed">
-                    문서를 불러올 수 없습니다. API 연결 상태를 확인해 주세요.
+                    {previewMessage ?? "문서를 불러올 수 없습니다. API 연결 상태를 확인해 주세요."}
                   </p>
                 </div>
              </div>

--- a/app/api/documents/[id]/source/route.ts
+++ b/app/api/documents/[id]/source/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import {
+  createAuthHeaders,
+  createUnauthorizedResponse,
+  fetchDocumentAgentApi,
+  getAccessToken,
+  proxyResponse,
+} from "@/lib/document-agent-backend"
+
+type RouteContext = {
+  params: Promise<{
+    id: string
+  }>
+}
+
+export async function GET(
+  request: NextRequest,
+  context: RouteContext,
+) {
+  const accessToken = await getAccessToken()
+  if (!accessToken) {
+    return createUnauthorizedResponse()
+  }
+
+  const { id } = await context.params
+
+  try {
+    // 백엔드 API 엔드포인트: GET /api/v1/documents/{document_id}/source
+    const response = await fetchDocumentAgentApi(
+      `/${["documents", id, "source"].join("/")}`,
+      {
+        method: "GET",
+        headers: createAuthHeaders(accessToken),
+      },
+      request.nextUrl.searchParams,
+    )
+    return proxyResponse(response)
+  } catch {
+    return NextResponse.json(
+      {
+        error: {
+          message: "문서 원본 API에 연결하지 못했습니다.",
+        },
+      },
+      { status: 503 },
+    )
+  }
+}

--- a/lib/document-agent-api.ts
+++ b/lib/document-agent-api.ts
@@ -121,3 +121,11 @@ export function getDownloadUrl(
   const query = new URLSearchParams({ format });
   return buildApiUrl(API_ROOT, `/${documentId}/download`, query);
 }
+
+export function getSourceUrl(
+  documentId: string,
+  disposition: "inline" | "attachment" = "inline",
+): string {
+  const query = new URLSearchParams({ disposition });
+  return buildApiUrl(API_ROOT, `/${documentId}/source`, query);
+}

--- a/lib/document-agent-backend.ts
+++ b/lib/document-agent-backend.ts
@@ -139,20 +139,26 @@ export function createUnauthorizedResponse() {
   )
 }
 
+const PROXY_RESPONSE_HEADER_NAMES = [
+  "accept-ranges",
+  "cache-control",
+  "content-disposition",
+  "content-length",
+  "content-range",
+  "content-type",
+  "etag",
+  "last-modified",
+  "x-content-type-options",
+] as const
+
 export function proxyResponse(response: Response): NextResponse {
   const headers = new Headers()
-  const contentType = response.headers.get("content-type")
-  const contentDisposition = response.headers.get("content-disposition")
-  const contentLength = response.headers.get("content-length")
 
-  if (contentType) {
-    headers.set("content-type", contentType)
-  }
-  if (contentDisposition) {
-    headers.set("content-disposition", contentDisposition)
-  }
-  if (contentLength) {
-    headers.set("content-length", contentLength)
+  for (const headerName of PROXY_RESPONSE_HEADER_NAMES) {
+    const headerValue = response.headers.get(headerName)
+    if (headerValue) {
+      headers.set(headerName, headerValue)
+    }
   }
 
   return new NextResponse(response.body, {


### PR DESCRIPTION
**변경 사항 요약**
 문서 상세 페이지의 좌측 패널에 실제 PDF/이미지 원본 파일을 볼 수 있는 미리보기 기능을 추가했습니다.

**주요 변경 내역**
* Proxy Route 추가: 백엔드의 인증된 세션을 통해 원본 파일을 안전하게 가져올 수 있도록 /api/documents/[id]/source 엔드포인트를 구현했습니다.
* API 클라이언트 확장: 원본 소스 URL을 생성하는 getSourceUrl 헬퍼 함수를 lib/document-agent-api.ts에 추가했습니다.
* UI 업데이트:
   * 기존의 플레이스홀더를 제거하고 iframe을 사용하여 원본 문서를 직접 렌더링합니다.
   * 상단 뱃지에 파일 형식(PDF 등)과 Source Loaded 상태를 동적으로 표시합니다.
* 인증 유지: Same-origin proxy를 경유하므로 기존의 accessToken 인증 방식을 그대로 유지하며 동작합니다.

**관련 이슈**
   * Closes #4