### PR TITLE
feat(web): support async parse job upload flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,47 @@
+name: Task
+description: Create a project task using the standard Summary / Background / Scope / Done format.
+title: "feat: "
+labels:
+  - task
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe what this task changes.
+      placeholder: |
+        `document-agent-web`에서 어떤 기능 또는 정리를 수행하는지 한두 문장으로 적어주세요.
+    validations:
+      required: true
+
+  - type: textarea
+    id: background
+    attributes:
+      label: Background
+      description: Explain why this task is needed now.
+      placeholder: |
+        현재 동작/제약과 이번 작업이 필요한 이유를 적어주세요.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: List the concrete implementation scope.
+      placeholder: |
+        - 구현 항목 1
+        - 구현 항목 2
+        - 구현 항목 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: done
+    attributes:
+      label: Done
+      description: Define the condition for completion.
+      placeholder: |
+        이 작업이 완료되었다고 볼 수 있는 상태를 적어주세요.
+    validations:
+      required: true

--- a/app/(dashboard)/upload/page.tsx
+++ b/app/(dashboard)/upload/page.tsx
@@ -52,7 +52,6 @@ export default function UploadPage() {
       }
 
       setErrorMessage("업로드는 완료되었지만 파싱이 아직 진행 중입니다. 문서 목록에서 잠시 후 다시 확인해 주세요.");
-      router.push("/documents");
     } catch (error) {
       console.error(error);
       if (error instanceof Error) {

--- a/app/(dashboard)/upload/page.tsx
+++ b/app/(dashboard)/upload/page.tsx
@@ -31,6 +31,7 @@ export default function UploadPage() {
 
     setUploading(true);
     setErrorMessage(null);
+    let navigatingToDocument = false;
 
     try {
       const queued = await uploadDocument(file);
@@ -44,6 +45,7 @@ export default function UploadPage() {
         }
 
         if (current.job.documentId) {
+          navigatingToDocument = true;
           router.push(`/documents/${current.job.documentId}`);
           return;
         }
@@ -60,7 +62,9 @@ export default function UploadPage() {
         setErrorMessage("An error occurred during upload.");
       }
     } finally {
-      setUploading(false);
+      if (!navigatingToDocument) {
+        setUploading(false);
+      }
     }
   };
 

--- a/app/(dashboard)/upload/page.tsx
+++ b/app/(dashboard)/upload/page.tsx
@@ -2,12 +2,19 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { uploadDocument } from "@/lib/document-agent-api";
+import { getParseJob, uploadDocument } from "@/lib/document-agent-api";
 import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Upload, Loader2, AlertCircle, CheckCircle2, Sparkles } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
+
+const POLL_INTERVAL_MS = 1000;
+const POLL_TIMEOUT_MS = 60000;
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export default function UploadPage() {
   const [file, setFile] = useState<File | null>(null);
@@ -26,8 +33,26 @@ export default function UploadPage() {
     setErrorMessage(null);
 
     try {
-      const parsed = await uploadDocument(file);
-      router.push(`/documents/${parsed.document.id}`);
+      const queued = await uploadDocument(file);
+      const startedAt = Date.now();
+
+      while (Date.now() - startedAt < POLL_TIMEOUT_MS) {
+        const current = await getParseJob(queued.job.id);
+
+        if (current.job.status === "failed") {
+          throw new Error(current.job.errorMessage ?? "문서 파싱에 실패했습니다.");
+        }
+
+        if (current.job.documentId) {
+          router.push(`/documents/${current.job.documentId}`);
+          return;
+        }
+
+        await wait(POLL_INTERVAL_MS);
+      }
+
+      setErrorMessage("업로드는 완료되었지만 파싱이 아직 진행 중입니다. 문서 목록에서 잠시 후 다시 확인해 주세요.");
+      router.push("/documents");
     } catch (error) {
       console.error(error);
       if (error instanceof Error) {
@@ -49,7 +74,7 @@ export default function UploadPage() {
               <Badge variant="secondary" className="bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 border-zinc-200 px-2 py-0 text-[10px]">Drag and Drop</Badge>
               <div className="space-y-1">
                 <h1 className="text-2xl font-bold">문서 업로드 워크벤치</h1>
-                <p className="text-zinc-500 text-sm">파일을 올리면 즉시 파싱 요청을 보내고, 성공 시 상세 검수 화면으로 이동합니다.</p>
+                <p className="text-zinc-500 text-sm">파일을 올리면 파싱 작업을 생성하고, 완료되면 상세 검수 화면으로 이동합니다.</p>
               </div>
             </div>
 
@@ -149,7 +174,7 @@ export default function UploadPage() {
               <ul className="space-y-3 text-[11px] text-zinc-500 leading-relaxed">
                 <li className="flex gap-2">
                   <span className="shrink-0">•</span>
-                  <span>문서 업로드 뒤 즉시 상세 Viewer로 이동합니다.</span>
+                  <span>문서 업로드 뒤 async parse job을 생성하고 완료 시 상세 Viewer로 이동합니다.</span>
                 </li>
                 <li className="flex gap-2">
                   <span className="shrink-0">•</span>

--- a/app/(dashboard)/upload/page.tsx
+++ b/app/(dashboard)/upload/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { getParseJob, uploadDocument } from "@/lib/document-agent-api";
 import { Card } from "@/components/ui/card"
@@ -21,6 +21,13 @@ export default function UploadPage() {
   const [uploading, setUploading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const router = useRouter();
+  const isActiveRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isActiveRef.current = false;
+    };
+  }, []);
 
   const handleUpload = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -37,7 +44,7 @@ export default function UploadPage() {
       const queued = await uploadDocument(file);
       const startedAt = Date.now();
 
-      while (Date.now() - startedAt < POLL_TIMEOUT_MS) {
+      while (isActiveRef.current && Date.now() - startedAt < POLL_TIMEOUT_MS) {
         const current = await getParseJob(queued.job.id);
 
         if (current.job.status === "failed") {
@@ -45,6 +52,9 @@ export default function UploadPage() {
         }
 
         if (current.job.documentId) {
+          if (!isActiveRef.current) {
+            return;
+          }
           navigatingToDocument = true;
           router.push(`/documents/${current.job.documentId}`);
           return;
@@ -53,16 +63,21 @@ export default function UploadPage() {
         await wait(POLL_INTERVAL_MS);
       }
 
-      setErrorMessage("업로드는 완료되었지만 파싱이 아직 진행 중입니다. 문서 목록에서 잠시 후 다시 확인해 주세요.");
+      if (isActiveRef.current) {
+        setErrorMessage("업로드는 완료되었지만 파싱이 아직 진행 중입니다. 문서 목록에서 잠시 후 다시 확인해 주세요.");
+      }
     } catch (error) {
       console.error(error);
+      if (!isActiveRef.current) {
+        return;
+      }
       if (error instanceof Error) {
         setErrorMessage(error.message);
       } else {
         setErrorMessage("An error occurred during upload.");
       }
     } finally {
-      if (!navigatingToDocument) {
+      if (isActiveRef.current && !navigatingToDocument) {
         setUploading(false);
       }
     }

--- a/app/api/parse-jobs/[id]/route.ts
+++ b/app/api/parse-jobs/[id]/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+
+import {
+  createAuthHeaders,
+  createUnauthorizedResponse,
+  fetchDocumentAgentApi,
+  getAccessToken,
+  parseBackendApiError,
+  proxyResponse,
+} from "@/lib/document-agent-backend";
+
+type RouteContext = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  const accessToken = await getAccessToken();
+  if (!accessToken) {
+    return createUnauthorizedResponse();
+  }
+
+  const { id } = await context.params;
+  if (!id) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "invalid_request",
+          message: "A parse job id is required.",
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const response = await fetchDocumentAgentApi(`/${["parse-jobs", id].join("/")}`, {
+      method: "GET",
+      headers: createAuthHeaders(accessToken),
+    });
+
+    if (!response.ok) {
+      const error = await parseBackendApiError(
+        response,
+        "파싱 작업 상태를 불러오지 못했습니다.",
+      );
+      return NextResponse.json(
+        {
+          error,
+        },
+        { status: response.status },
+      );
+    }
+
+    return proxyResponse(response);
+  } catch {
+    return NextResponse.json(
+      {
+        error: {
+          message: "문서 API에 연결하지 못했습니다.",
+        },
+      },
+      { status: 503 },
+    );
+  }
+}

--- a/lib/document-agent-api.ts
+++ b/lib/document-agent-api.ts
@@ -17,6 +17,24 @@ export type DocumentResponse = {
   document: DocumentSummary;
 };
 
+export type ParseJobSummary = {
+  id: string;
+  filename: string;
+  contentType: string;
+  status: "queued" | "processing" | "succeeded" | "failed";
+  documentId: string | null;
+  errorCode: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+  updatedAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+};
+
+export type ParseJobResponse = {
+  job: ParseJobSummary;
+};
+
 export type DocumentParseResponse = {
   document: DocumentSummary;
   result: ParseResult;
@@ -32,14 +50,15 @@ export type DocumentListResponse = {
 export type DownloadFormat = "markdown" | "json";
 
 const API_ROOT = "/api/documents";
+const PARSE_JOBS_API_ROOT = "/api/parse-jobs";
 
 export async function uploadDocument(
   file: File,
-): Promise<DocumentParseResponse> {
+): Promise<ParseJobResponse> {
   const formData = new FormData();
   formData.append("file", file);
 
-  return requestJson<DocumentParseResponse>({
+  return requestJson<ParseJobResponse>({
     apiRoot: API_ROOT,
     path: "/",
     init: {
@@ -47,6 +66,17 @@ export async function uploadDocument(
       body: formData,
     },
     fallbackMessage: "API 요청에 실패했습니다.",
+  });
+}
+
+export async function getParseJob(jobId: string): Promise<ParseJobResponse> {
+  return requestJson<ParseJobResponse>({
+    apiRoot: PARSE_JOBS_API_ROOT,
+    path: `/${jobId}`,
+    init: {
+      method: "GET",
+    },
+    fallbackMessage: "파싱 작업 상태를 불러오지 못했습니다.",
   });
 }
 


### PR DESCRIPTION
## Summary

`document-agent-web`에서 비동기 parse job 업로드 흐름을 처리할 수 있도록 정리합니다.

- 웹 레포용 task issue template 추가
- 업로드 응답을 async parse job 기준으로 변경
- `documentId`가 생길 때까지 parse job 상태를 polling 하도록 수정
- `GET /parse-jobs/{id}` proxy route 추가
- 업로드 화면 문구를 현재 비동기 흐름에 맞게 정리

## Why

현재 `document-agent-api`는 업로드 직후 파싱된 `document`를 반환하지 않고 `parse job`을 생성해 `202 Accepted`를 반환합니다.

하지만 웹 업로드 화면은 여전히 동기 처리 기준으로 `document.id`를 바로 읽고 있어 업로드 이후 상세 화면 이동에서 에러가 발생합니다.  
이번 변경으로 웹도 비동기 parse 완료를 기다린 뒤 `documentId`가 생기면 상세 검수 화면으로 이동하도록 맞춥니다.

## Screenshot

<img width="1512" height="1044" alt="image" src="https://github.com/user-attachments/assets/0a731110-1907-4abb-b463-3d63b71c11aa" />


## Verification

- `pnpm lint`

Closes #6
