### PR TITLE
feat(web): support document_ai upload flow (#12)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
 # document-agent-api base URL used by server-side auth and proxy routes.
 DOCUMENT_AGENT_API_BASE_URL=http://127.0.0.1:8000
+
+# document_ai 파서를 로컬 환경에서만 허용하려면 true로 설정합니다.
+DOCUMENT_AI_PARSER_ENABLED=true
+
+# Next.js 클라이언트 렌더링에서 document_ai 선택지를 노출할지 제어합니다.
+NEXT_PUBLIC_DOCUMENT_AI_PARSER_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,5 @@
 # document-agent-api base URL used by server-side auth and proxy routes.
 DOCUMENT_AGENT_API_BASE_URL=http://127.0.0.1:8000
 
-# document_ai 파서를 로컬 환경에서만 허용하려면 true로 설정합니다.
-DOCUMENT_AI_PARSER_ENABLED=true
-
-# Next.js 클라이언트 렌더링에서 document_ai 선택지를 노출할지 제어합니다.
+# Next.js 클라이언트와 proxy route에서 document_ai 선택지를 함께 제어합니다.
 NEXT_PUBLIC_DOCUMENT_AI_PARSER_ENABLED=true

--- a/app/(dashboard)/documents/[id]/page.tsx
+++ b/app/(dashboard)/documents/[id]/page.tsx
@@ -3,13 +3,13 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
 import {
   ArrowLeft,
   Loader2,
   Trash2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { SourcePreviewPanel } from "@/components/dashboard/source-preview-panel";
 import { ResultViewerPanel } from "@/components/dashboard/result-viewer-panel";
 import {
   deleteDocument,
@@ -20,6 +20,11 @@ import {
   getSourceUrl,
   ParseResult,
 } from "@/lib/document-agent-api";
+
+const SourcePreviewPanel = dynamic(
+  () => import("@/components/dashboard/source-preview-panel").then((module) => module.SourcePreviewPanel),
+  { ssr: false },
+);
 
 export default function DocumentDetailPage() {
   const params = useParams<{ id: string }>();

--- a/app/(dashboard)/upload/page.tsx
+++ b/app/(dashboard)/upload/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import dynamic from "next/dynamic";
 import {
   FileSpreadsheet,
   FileText,
@@ -12,7 +13,6 @@ import {
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { SourcePreviewPanel } from "@/components/dashboard/source-preview-panel";
 import { ResultViewerPanel } from "@/components/dashboard/result-viewer-panel";
 import {
   DEFAULT_PARSER_BACKEND,
@@ -32,13 +32,25 @@ import {
 
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 60000;
+const SHOW_DOCUMENT_AI_PARSER = process.env.NEXT_PUBLIC_DOCUMENT_AI_PARSER_ENABLED === "true";
+
+const SourcePreviewPanel = dynamic(
+  () => import("@/components/dashboard/source-preview-panel").then((module) => module.SourcePreviewPanel),
+  { ssr: false },
+);
 
 function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function parserLabel(parserBackend: ParserBackend): string {
-  return parserBackend === "markitdown" ? "MarkItDown" : "pdftotext";
+  if (parserBackend === "markitdown") {
+    return "MarkItDown";
+  }
+  if (parserBackend === "pdftotext") {
+    return "pdftotext";
+  }
+  return "document_ai";
 }
 
 function UploadConfigPanel({
@@ -115,6 +127,31 @@ function UploadConfigPanel({
               </Badge>
             </div>
           </button>
+
+          {SHOW_DOCUMENT_AI_PARSER ? (
+            <button
+              type="button"
+              onClick={() => onParserBackendChange("document_ai")}
+              disabled={uploading}
+              className={`rounded-xl border px-4 py-3 text-left transition ${
+                parserBackend === "document_ai"
+                  ? "border-[#96b24a] bg-[#f4f8df] shadow-[0_10px_30px_rgba(150,178,74,0.10)]"
+                  : "border-zinc-200 bg-white hover:border-zinc-300"
+              }`}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-zinc-900">document_ai</p>
+                  <p className="mt-1 text-xs leading-5 text-zinc-500">
+                    PDF 전용 문서 AI 파서를 로컬 환경에서만 사용합니다.
+                  </p>
+                </div>
+                <Badge variant="outline" className="border-[#dbe6a6] bg-[#fbfde9] text-[#667226]">
+                  로컬 전용
+                </Badge>
+              </div>
+            </button>
+          ) : null}
         </div>
       </section>
 
@@ -194,6 +231,16 @@ export default function UploadPage() {
 
     if (parserBackend === "pdftotext" && !isPdfFile(selectedFile)) {
       setErrorMessage("`pdftotext` 파서는 PDF 파일에서만 사용할 수 있습니다. MarkItDown으로 바꾸거나 PDF를 선택해 주세요.");
+      setSuccessMessage(null);
+      setParsedDocument(null);
+      setParsedResult(null);
+      setFile(selectedFile);
+      setPanelTab("config");
+      return;
+    }
+
+    if (parserBackend === "document_ai" && !isPdfFile(selectedFile)) {
+      setErrorMessage("`document_ai` 파서는 PDF 파일에서만 사용할 수 있습니다. PDF를 선택해 주세요.");
       setSuccessMessage(null);
       setParsedDocument(null);
       setParsedResult(null);

--- a/app/(dashboard)/upload/page.tsx
+++ b/app/(dashboard)/upload/page.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { ResultViewerPanel } from "@/components/dashboard/result-viewer-panel";
 import {
   DEFAULT_PARSER_BACKEND,
+  DOCUMENT_AI_PARSER_ENABLED,
   DocumentSummary,
   getDocumentResult,
   getParseJob,
@@ -32,7 +33,6 @@ import {
 
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 60000;
-const SHOW_DOCUMENT_AI_PARSER = process.env.NEXT_PUBLIC_DOCUMENT_AI_PARSER_ENABLED === "true";
 
 const SourcePreviewPanel = dynamic(
   () => import("@/components/dashboard/source-preview-panel").then((module) => module.SourcePreviewPanel),
@@ -128,7 +128,7 @@ function UploadConfigPanel({
             </div>
           </button>
 
-          {SHOW_DOCUMENT_AI_PARSER ? (
+          {DOCUMENT_AI_PARSER_ENABLED ? (
             <button
               type="button"
               onClick={() => onParserBackendChange("document_ai")}

--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -9,7 +9,12 @@ import {
   proxyResponse,
 } from "@/lib/document-agent-backend"
 
-const VALID_PARSER_BACKENDS = new Set(["markitdown", "pdftotext"])
+const VALID_PARSER_BACKENDS = new Set(["markitdown", "pdftotext", "document_ai"])
+const DOCUMENT_AI_PARSER_ENABLED = process.env.DOCUMENT_AI_PARSER_ENABLED === "true"
+
+const ALLOWED_PARSER_BACKENDS = DOCUMENT_AI_PARSER_ENABLED
+  ? VALID_PARSER_BACKENDS
+  : new Set(["markitdown", "pdftotext"])
 
 export async function GET(request: NextRequest) {
   const accessToken = await getAccessToken()
@@ -50,7 +55,7 @@ export async function POST(request: NextRequest) {
     const query = new URLSearchParams()
     const parserBackend = request.nextUrl.searchParams.get("parserBackend")
     if (parserBackend) {
-      if (!VALID_PARSER_BACKENDS.has(parserBackend)) {
+      if (!ALLOWED_PARSER_BACKENDS.has(parserBackend)) {
         return NextResponse.json(
           {
             error: {

--- a/app/api/documents/route.ts
+++ b/app/api/documents/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server"
 
 import {
+  DOCUMENT_AI_PARSER_ENABLED,
+} from "@/lib/document-agent-api"
+
+import {
   createAuthHeaders,
   createUnauthorizedResponse,
   fetchDocumentAgentApi,
@@ -10,7 +14,6 @@ import {
 } from "@/lib/document-agent-backend"
 
 const VALID_PARSER_BACKENDS = new Set(["markitdown", "pdftotext", "document_ai"])
-const DOCUMENT_AI_PARSER_ENABLED = process.env.DOCUMENT_AI_PARSER_ENABLED === "true"
 
 const ALLOWED_PARSER_BACKENDS = DOCUMENT_AI_PARSER_ENABLED
   ? VALID_PARSER_BACKENDS

--- a/lib/document-agent-api.ts
+++ b/lib/document-agent-api.ts
@@ -1,6 +1,6 @@
 import { buildApiUrl, requestJson, requestVoid } from "@/lib/api-client";
 
-export type ParserBackend = "markitdown" | "pdftotext"
+export type ParserBackend = "markitdown" | "pdftotext" | "document_ai"
 export type PanelTab = "config" | "result"
 export type SourcePreviewMode = "pdf" | "image" | "docx" | "xlsx" | "pptx" | "embed"
 

--- a/lib/document-agent-api.ts
+++ b/lib/document-agent-api.ts
@@ -1,5 +1,8 @@
 import { buildApiUrl, requestJson, requestVoid } from "@/lib/api-client";
 
+export const DOCUMENT_AI_PARSER_ENABLED =
+  process.env.NEXT_PUBLIC_DOCUMENT_AI_PARSER_ENABLED === "true"
+
 export type ParserBackend = "markitdown" | "pdftotext" | "document_ai"
 export type PanelTab = "config" | "result"
 export type SourcePreviewMode = "pdf" | "image" | "docx" | "xlsx" | "pptx" | "embed"


### PR DESCRIPTION
## Summary

- 업로드 화면에서 `document_ai` parser 선택을 지원합니다.
- 로컬 환경 플래그에 따라 `document_ai` 옵션 노출 여부를 제어합니다.
- `/api/documents` route에서 `document_ai` backend 전달을 허용합니다.
- `SourcePreviewPanel`을 dynamic import로 바꿔 클라이언트 전용 렌더링 경계를 맞춥니다.

## Why

로컬 통합 스택에서 `document_ai` parser를 실제로 선택하고 업로드 흐름까지 연결하려면 웹에서도 parser backend를 명시적으로 다뤄야 합니다.  
또한 `document_ai`는 PDF 전용 parser이므로 업로드 시점에 파일 형식 제약을 먼저 안내해야 잘못된 요청을 줄일 수 있습니다.

## Screenshot

- 없음

## Verification

- `NEXT_PUBLIC_DOCUMENT_AI_PARSER_ENABLED=true`일 때 업로드 화면에 `document_ai` 옵션이 노출됨
- PDF가 아닌 파일에서 `document_ai`를 선택하면 안내 메시지가 표시됨
- `/api/documents` route가 `parserBackend=document_ai`를 거부하지 않음
- 로컬 통합 스택에서 `document_ai` 업로드 요청이 정상적으로 전달됨